### PR TITLE
Add -Wno-class-memaccess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(basalt_wrapper)
 
 # sophus and cereal must be installed or else the generation
 # of the basalt-headerTargets.cmake fails
+add_compile_options(-Wno-class-memaccess)
 
 set(SOPHUS_INSTALL ON CACHE BOOL "install sophus")
 set(CEREAL_INSTALL ON CACHE BOOL "install cereal")


### PR DESCRIPTION
One minor change I found while bashing on basalt on the Nano.

This _prevents_ the `class-access` warning from being raised, which is elevated to an error during the build.